### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lainra/claude-code-telemetry/security/code-scanning/6](https://github.com/lainra/claude-code-telemetry/security/code-scanning/6)

To fix the problem, add a top-level `permissions` block to the workflow file `.github/workflows/ci.yml`, immediately after the `name:` line and before the `on:` block. This block should set the minimal required permissions for the workflow, which is typically `contents: read` unless more permissions are needed. Since only the `security` job requires additional permissions (and already sets them), setting `permissions: contents: read` at the workflow level is appropriate and will apply to all jobs except those that override it (like `security`). No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
